### PR TITLE
DB 구축 및 일부 UI와 연결

### DIFF
--- a/lib/models/dial.dart
+++ b/lib/models/dial.dart
@@ -1,5 +1,8 @@
+import 'dart:ui';
+
 import 'package:plan_dial_renewal/models/time.dart';
 import 'package:plan_dial_renewal/models/week_schedule.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
 
 /// Default Dial Class
 class Dial {
@@ -7,17 +10,15 @@ class Dial {
   final int id;
   DateTime startTime;
 
-  int? durationInSeconds;
   bool disabled;
-  WeekSchedule schedule;
+  WeekSchedule weekSchedule;
 
   Dial(
       {required this.name,
       required this.id,
       required this.startTime,
-      this.durationInSeconds,
       this.disabled = false,
-      required this.schedule});
+      required this.weekSchedule});
 
   /// 현재로부터 가장 가까운 알람 시기를 리턴하는 함수.
   DateTime? getNearestDateTime() {
@@ -28,14 +29,16 @@ class Dial {
       return startTime;
     } else {
       final weekday = now.weekday;
-      final todaySchedule = schedule.getTimeByIndex(weekday);
+      final todaySchedule = weekSchedule.getScheduleByIndex(weekday);
 
-      if (todaySchedule == null || !todaySchedule.isLaterThan(Time.now())) {
-        return schedule
-            .getNearestTime(weekday)
-            ?.toDateTime(now.year, now.month, now.day);
+      if (todaySchedule == null ||
+          !todaySchedule.start.isLaterThan(Time.now())) {
+        return weekSchedule
+            .getNearestSchedule(weekday)
+            ?.start
+            .toDateTime(now.year, now.month, now.day);
       } else {
-        return todaySchedule.toDateTime(now.year, now.month, now.day);
+        return todaySchedule.start.toDateTime(now.year, now.month, now.day);
       }
     }
   }
@@ -48,7 +51,7 @@ class Dial {
     if (date == null) {
       return -1;
     } else {
-      return now.difference(date).inSeconds;
+      return date.difference(now).inSeconds;
     }
   }
 
@@ -63,5 +66,15 @@ class Dial {
       seconds %= 60;
       return seconds.toString() + "분 전";
     }
+  }
+
+  /// 해당 요일에 스케줄이 있는지 확인하는 함수
+  bool hasSchedule(int weekday) {
+    return weekSchedule.getScheduleByIndex(weekday) != null;
+  }
+
+  /// 스케줄들을 Appointment로 반환하는 함수
+  List<Appointment> toAppointments(Color color) {
+    return weekSchedule.toAppointments(name, color);
   }
 }

--- a/lib/models/dial_manager.dart
+++ b/lib/models/dial_manager.dart
@@ -1,8 +1,12 @@
+import 'package:flutter/cupertino.dart';
 import 'package:plan_dial_renewal/models/dial.dart';
+import 'package:plan_dial_renewal/models/week_schedule.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
 
 class DialManager {
   static final DialManager _instance = DialManager._internal();
   static final Map dials = <int, Dial>{};
+  static int id = 1;
 
   factory DialManager() {
     return _instance;
@@ -28,10 +32,20 @@ class DialManager {
     return dials.values.toList();
   }
 
+  void addDial(String name, DateTime startTime, WeekSchedule schedule) {
+    dials[id] = Dial(
+      name: name,
+      id: id++,
+      startTime: startTime,
+      weekSchedule: schedule,
+    );
+  }
+
   void removeAllDials() {
     dials.clear();
   }
 
+  /// 가장 가까운 다이얼 딱 1개 리턴
   Dial? getUrgentDial() {
     if (getDialCount() == 0) return null;
 
@@ -43,6 +57,30 @@ class DialManager {
         result = dial;
         seconds = dial.getLeftTimeInSeconds();
       }
+    }
+
+    return result;
+  }
+
+  /// 오늘에 해당되는 다이얼 모두 리턴
+  List<Dial> getTodayDials() {
+    var result = List<Dial>.empty();
+
+    for (Dial dial in getAllDials()) {
+      if (dial.hasSchedule(DateTime.now().weekday)) {
+        result.add(dial);
+      }
+    }
+
+    return result;
+  }
+
+  /// 모든 다이얼의 일정 Appointment로 리턴
+  List<Appointment> getAllDialsAsAppointments() {
+    var result = List<Appointment>.empty();
+
+    for (Dial dial in getAllDials()) {
+      result.addAll(dial.toAppointments(CupertinoColors.activeBlue));
     }
 
     return result;

--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -1,0 +1,29 @@
+import 'dart:ui';
+
+import 'package:plan_dial_renewal/models/time.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
+
+/// 시작일, 종료일을 담는 클래스
+class Schedule {
+  static const defaultDuration = 1;
+  final Time start;
+  late final Time finish;
+
+  Schedule(this.start, [Time? finish]) {
+    if (finish == null) {
+      this.finish = Time(start.hour + defaultDuration, start.minute);
+    } else {
+      assert(finish.isLaterThan(start)); // start가 finish 이전이어야 함.
+      this.finish = finish;
+    }
+  }
+
+  Appointment toAppointment(String title, Color color, DateTime date) {
+    return Appointment(
+      startTime: start.toDateTime(date.year, date.month, date.day),
+      endTime: finish.toDateTime(date.year, date.month, date.day),
+      subject: title,
+      color: color,
+    );
+  }
+}

--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -26,4 +26,15 @@ class Schedule {
       color: color,
     );
   }
+
+  @override
+  String toString() {
+    return start.toString() + "~" + finish.toString();
+  }
+
+  static Schedule? parse(String string) {
+    if (string.isEmpty) return null;
+    var split = string.split("~");
+    return Schedule(Time.parse(split[0]), Time.parse(split[1]));
+  }
 }

--- a/lib/models/time.dart
+++ b/lib/models/time.dart
@@ -17,6 +17,16 @@ class Time {
     }
   }
 
+  @override
+  String toString() {
+    return hour.toString() + ":" + minute.toString();
+  }
+
+  static Time parse(String string) {
+    var split = string.split(":");
+    return Time(int.parse(split[0]), int.parse(split[1]));
+  }
+
   static Time now() {
     final now = DateTime.now();
     return Time(now.hour, now.minute);

--- a/lib/models/week_schedule.dart
+++ b/lib/models/week_schedule.dart
@@ -44,29 +44,31 @@ class WeekSchedule {
     }
   }
 
-  /// 가장 가까운 일정이 있는 요일의 일정을 반환하는 함수 (오늘 제외)
-  Schedule? getNearestSchedule(int weekdayIndex) {
+  /// 가장 가까운 일정이 있는 요일을 반환하는 함수
+  int getNearestSchedule(int weekdayIndex) {
+    if (getScheduleByIndex(weekdayIndex) != null) return weekdayIndex;
+
     int index = weekdayIndex % 7 + 1;
 
     while (index != weekdayIndex) {
-      final schedule = getScheduleByIndex(weekdayIndex);
-      if (schedule != null) return schedule;
+      final schedule = getScheduleByIndex(index);
+      if (schedule != null) return index;
       index = index % 7 + 1;
     }
 
-    return null;
+    return 0;
   }
 
   /// 스케줄들을 Appointment로 반환하는 함수
   List<Appointment> toAppointments(String title, Color color) {
-    var result = List<Appointment>.empty();
+    var result = List<Appointment>.empty(growable: true);
 
     DateTime baseDate = DateTime.now();
     Duration baseDuration = const Duration(days: 1);
-    baseDate.subtract(Duration(days: baseDate.weekday));
+    baseDate = baseDate.subtract(Duration(days: baseDate.weekday));
 
     for (int i = 1; i <= 7; ++i) {
-      baseDate.add(baseDuration);
+      baseDate = baseDate.add(baseDuration);
       var schedule = getScheduleByIndex(i);
       if (schedule != null) {
         result.add(schedule.toAppointment(title, color, baseDate));

--- a/lib/models/week_schedule.dart
+++ b/lib/models/week_schedule.dart
@@ -1,14 +1,17 @@
-import 'package:plan_dial_renewal/models/time.dart';
+import 'dart:ui';
+
+import 'package:plan_dial_renewal/models/schedule.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
 
 /// 일주일 일정 스케쥴을 담는 클래스
 class WeekSchedule {
-  final Time? monday;
-  final Time? tuesday;
-  final Time? wednesday;
-  final Time? thursday;
-  final Time? friday;
-  final Time? saturday;
-  final Time? sunday;
+  final Schedule? monday;
+  final Schedule? tuesday;
+  final Schedule? wednesday;
+  final Schedule? thursday;
+  final Schedule? friday;
+  final Schedule? saturday;
+  final Schedule? sunday;
 
   WeekSchedule(
       {this.monday,
@@ -20,7 +23,7 @@ class WeekSchedule {
       this.sunday});
 
   /// 인덱스로 일정에 접근하는 함수
-  Time? getTimeByIndex(int weekdayIndex) {
+  Schedule? getScheduleByIndex(int weekdayIndex) {
     switch (weekdayIndex) {
       case DateTime.monday:
         return monday;
@@ -42,15 +45,34 @@ class WeekSchedule {
   }
 
   /// 가장 가까운 일정이 있는 요일의 일정을 반환하는 함수 (오늘 제외)
-  Time? getNearestTime(int weekdayIndex) {
+  Schedule? getNearestSchedule(int weekdayIndex) {
     int index = weekdayIndex % 7 + 1;
 
     while (index != weekdayIndex) {
-      final schedule = getTimeByIndex(weekdayIndex);
+      final schedule = getScheduleByIndex(weekdayIndex);
       if (schedule != null) return schedule;
       index = index % 7 + 1;
     }
 
     return null;
+  }
+
+  /// 스케줄들을 Appointment로 반환하는 함수
+  List<Appointment> toAppointments(String title, Color color) {
+    var result = List<Appointment>.empty();
+
+    DateTime baseDate = DateTime.now();
+    Duration baseDuration = const Duration(days: 1);
+    baseDate.subtract(Duration(days: baseDate.weekday));
+
+    for (int i = 1; i <= 7; ++i) {
+      baseDate.add(baseDuration);
+      var schedule = getScheduleByIndex(i);
+      if (schedule != null) {
+        result.add(schedule.toAppointment(title, color, baseDate));
+      }
+    }
+
+    return result;
   }
 }

--- a/lib/screens/Check_List.dart
+++ b/lib/screens/Check_List.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:plan_dial_renewal/models/dial_manager.dart';
 
 class CheckList extends StatefulWidget {
   const CheckList({Key? key}) : super(key: key);
@@ -10,17 +11,23 @@ class CheckList extends StatefulWidget {
 class _CheckListState extends State<CheckList> {
   @override
   Widget build(BuildContext context) {
+    final todayDials = DialManager().getTodayDials();
+
     return ListView(
       shrinkWrap: true,
       padding: const EdgeInsets.all(8),
-      children: const [CheckBox(), CheckBox(), CheckBox(), CheckBox()],
+      children: List.generate(todayDials.length, (i) {
+        return CheckBox(todayDials[i].name);
+      }),
     );
   }
 }
 
 // To Do List Check Box
 class CheckBox extends StatefulWidget {
-  const CheckBox({Key? key}) : super(key: key);
+  final String title;
+
+  const CheckBox(this.title, {Key? key}) : super(key: key);
 
   @override
   State<CheckBox> createState() => _CheckBoxTestState();
@@ -28,13 +35,14 @@ class CheckBox extends StatefulWidget {
 
 class _CheckBoxTestState extends State<CheckBox> {
   bool state = false;
+
   @override
   Widget build(BuildContext context) {
     return CupertinoButton(
         pressedOpacity: 1,
-        child: const Text(
-          '빨래하기',
-          style: TextStyle(
+        child: Text(
+          widget.title,
+          style: const TextStyle(
               color: CupertinoColors.white, fontWeight: FontWeight.bold),
         ),
         color: state ? CupertinoColors.activeBlue : CupertinoColors.systemGrey4,

--- a/lib/screens/calendar.dart
+++ b/lib/screens/calendar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:plan_dial_renewal/models/dial_manager.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 
 class Calendar extends StatefulWidget {
@@ -16,16 +17,17 @@ class _CalendarState extends State<Calendar> {
       timeSlotViewSettings:
           const TimeSlotViewSettings(timeInterval: Duration(hours: 2)),
       headerHeight: 0,
-      dataSource: MeetingDataSource(getAppointments()),
+      dataSource: MeetingDataSource(DialManager().getAllDialsAsAppointments()),
     );
   }
 }
 
+@Deprecated("For Test")
 List<Appointment> getAppointments() {
   List<Appointment> meetings = <Appointment>[];
   final DateTime today = DateTime.now();
   final DateTime startTime =
-      DateTime(today.year, today.month, today.day, 13, 0, 0);
+  DateTime(today.year, today.month, today.day, 13, 0, 0);
   final DateTime endTime = startTime.add(const Duration(hours: 1));
 
   meetings.add(Appointment(

--- a/lib/utils/databases/db_manager.dart
+++ b/lib/utils/databases/db_manager.dart
@@ -1,0 +1,163 @@
+import 'package:path/path.dart';
+import 'package:plan_dial_renewal/models/dial.dart';
+import 'package:plan_dial_renewal/models/schedule.dart';
+import 'package:plan_dial_renewal/models/week_schedule.dart';
+import 'package:sqflite/sqflite.dart';
+
+// TODO 체크리스트 DB 쿼리 작성
+class DbManager {
+  static const _version = 1;
+  static const _dbName = "dialTable.db";
+
+  static final DbManager _instance = DbManager._internal();
+
+  factory DbManager() {
+    return _instance;
+  }
+
+  DbManager._internal() {
+    // TODO 최초 1회 생성자 내용 넣기
+  }
+
+  Future<Database> _getDatabase() async {
+    return openDatabase(
+      join(await getDatabasesPath(), _dbName),
+      onCreate: (db, version) {
+        db.execute(
+            "CREATE TABLE dial(id INTEGER PRIMARY KEY, name TEXT, startTime TEXT, disabled INTEGER)");
+        db.execute(
+            "CREATE TABLE schedule(id INTEGER, name TEXT, monday TEXT, tuesday TEXT, wednesday TEXT, thursday TEXT, friday TEXT, saturday TEXT, sunday TEXT)");
+        db.execute(
+            "CREATE TABLE checklist(id INTEGER, name TEXT, date TEXT, archived INTEGER)");
+      },
+      version: _version,
+    );
+  }
+
+  Future<void> clear() async {
+    deleteDatabase(join(await getDatabasesPath(), _dbName));
+  }
+
+  Future<Map<int, Dial>> loadAllDials() async {
+    final result = <int, Dial>{};
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> maps =
+        await db.query('dial INNER JOIN schedule ON dial.id = schedule.id');
+
+    for (var map in maps) {
+      result[map['id']] = Dial(
+        id: map['id'],
+        name: map['name'],
+        startTime: DateTime.parse(map['startTime']),
+        weekSchedule: WeekSchedule(
+          monday: Schedule.parse(map['monday']),
+          tuesday: Schedule.parse(map['tuesday']),
+          wednesday: Schedule.parse(map['wednesday']),
+          thursday: Schedule.parse(map['thursday']),
+          friday: Schedule.parse(map['friday']),
+          saturday: Schedule.parse(map['saturday']),
+          sunday: Schedule.parse(map['sunday']),
+        ),
+        disabled: map['disabled'] == 1,
+      );
+    }
+
+    return result;
+  }
+
+  Future<void> deleteDialByIndex(int index) async {
+    final Database db = await _getDatabase();
+
+    await db.delete(
+      'dial',
+      where: "id = ?",
+      whereArgs: [index],
+    );
+
+    await db.delete(
+      'schedule',
+      where: "id = ?",
+      whereArgs: [index],
+    );
+
+    await db.delete(
+      'checklist',
+      where: "id = ?",
+      whereArgs: [index],
+    );
+  }
+
+  Future<int> addDial(Dial dial) async {
+    final Database db = await _getDatabase();
+
+    int id = await db.insert(
+      'dial',
+      {
+        'name': dial.name,
+        'startTime': dial.startTime.toString(),
+        'disabled': dial.disabled ? 1 : 0,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
+    await db.insert(
+      'schedule',
+      {
+        'id': id,
+        'name': dial.name,
+        'monday': (dial.weekSchedule.monday ?? "").toString(),
+        'tuesday': (dial.weekSchedule.tuesday ?? "").toString(),
+        'wednesday': (dial.weekSchedule.wednesday ?? "").toString(),
+        'thursday': (dial.weekSchedule.thursday ?? "").toString(),
+        'friday': (dial.weekSchedule.friday ?? "").toString(),
+        'saturday': (dial.weekSchedule.saturday ?? "").toString(),
+        'sunday': (dial.weekSchedule.sunday ?? "").toString(),
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+
+    return id;
+  }
+
+  Future<void> updateDial(Dial dial) async {
+    final Database db = await _getDatabase();
+
+    await db.update(
+      'dial',
+      {
+        'name': dial.name,
+        'startTime': dial.startTime.toString(),
+        'disabled': dial.disabled ? 1 : 0,
+      },
+      where: "id = ?",
+      whereArgs: [dial.id],
+    );
+
+    await db.update(
+      'schedule',
+      {
+        'id': dial.id,
+        'name': dial.name,
+        'monday': (dial.weekSchedule.monday ?? "").toString(),
+        'tuesday': (dial.weekSchedule.tuesday ?? "").toString(),
+        'wednesday': (dial.weekSchedule.wednesday ?? "").toString(),
+        'thursday': (dial.weekSchedule.thursday ?? "").toString(),
+        'friday': (dial.weekSchedule.friday ?? "").toString(),
+        'saturday': (dial.weekSchedule.saturday ?? "").toString(),
+        'sunday': (dial.weekSchedule.sunday ?? "").toString(),
+      },
+      where: "id = ?",
+      whereArgs: [dial.id],
+    );
+  }
+
+  Future<int> getNextId() async {
+    final Database db = await _getDatabase();
+
+    List<Map<String, dynamic>> maps =
+        await db.rawQuery('SELECT MAX(id) FROM dial');
+
+    print(maps.toString());
+    return (maps[0]['id'] ?? 0) + 1;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,7 +131,7 @@ packages:
     source: hosted
     version: "1.7.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
@@ -156,6 +156,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -198,6 +212,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "20.1.51"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0+2"
   term_glyph:
     dependency: transitive
     description:
@@ -235,3 +256,4 @@ packages:
     version: "2.1.1"
 sdks:
   dart: ">=2.16.1 <3.0.0"
+  flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   cupertino_list_tile: ^0.2.0
   syncfusion_flutter_calendar: ^20.1.51
 
+  sqflite:
+  path:
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/dial_managing_test.dart
+++ b/test/dial_managing_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_dial_renewal/models/dial.dart';
+import 'package:plan_dial_renewal/models/dial_manager.dart';
+import 'package:plan_dial_renewal/models/schedule.dart';
+import 'package:plan_dial_renewal/models/time.dart';
+import 'package:plan_dial_renewal/models/week_schedule.dart';
+
+void main() {
+  test("다이얼 매니저 초기 생성 테스트", () {
+    var dialManager = DialManager();
+    expect(dialManager.getDialCount(), equals(0));
+    expect(dialManager.getAllDials(), isEmpty);
+    expect(dialManager.getUrgentDial(), isNull);
+    expect(dialManager.getTodayDials(), isEmpty);
+    expect(dialManager.getAllDialsAsAppointments(), isEmpty);
+  });
+
+  test("다이얼 생성 테스트", () {
+    var dial = Dial(
+      name: "다이얼1",
+      id: 1,
+      startTime: DateTime.now(),
+      weekSchedule: WeekSchedule(
+        monday: Schedule(
+          Time(10, 30),
+        ),
+      ),
+    );
+
+    expect(dial.getNearestDateTime(), isNotNull);
+    expect(dial.getLeftTimeInSeconds(), isPositive);
+  });
+}


### PR DESCRIPTION
## 개요
+ DB 구축
+ DB 저장, 삭제 및 불러오는 부분을 DialManager와 연동
+ 백엔드 부분과 UI 일부 연동

## 변경 사항
개요의 내용 모두 작업했습니다. 자세한 사항은 추후 회의 때 말씀 드리겠습니다!

## 확인 방법 (스크린샷 첨부 가능)
<img src="https://user-images.githubusercontent.com/43088187/166446082-37dcb30b-3795-496a-ab2f-5d3fceb0c697.png" width="45%" > <img src="https://user-images.githubusercontent.com/43088187/166446093-58a4bc24-107c-46f7-8924-9db5b7396257.png" width="45%">


## 한계점 / 문제점
+ 지난 버전부터 계속된 문제이긴 한데, 현재 상황에서 테스트하기 굉장히 어렵습니다.
+ 현재 메인 페이지에만 Observer 패턴을 적용한 상태라, 추후 다른 UI 위젯에도 달면 좋을 거 같아요!
+ 체크 리스트 관련 DB 부분 아직 미완성입니다.