### PR TITLE
캘린더에 다이얼별 색상 적용

### DIFF
--- a/lib/models/dial_manager.dart
+++ b/lib/models/dial_manager.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:plan_dial_renewal/models/dial.dart';
+import 'package:plan_dial_renewal/models/schedule.dart';
+import 'package:plan_dial_renewal/models/time.dart';
 import 'package:plan_dial_renewal/models/week_schedule.dart';
 import 'package:plan_dial_renewal/utils/db_manager.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 
+import '../utils/colors.dart';
 import '../utils/noti_manager.dart';
 
 class DialManager {
@@ -12,22 +15,39 @@ class DialManager {
   static final DialManager _instance = DialManager._internal();
   static final Map dials = <int, Dial>{};
   static final List<Observer> _observers = List.empty(growable: true);
+  static final List<Color> _colors = List.empty(growable: true);
 
   factory DialManager() {
     return _instance;
   }
 
   DialManager._internal() {
+    _colors.addAll(getRainbowColors(230, 170));
+    _colors.addAll(getRainbowColors(200, 100));
+    _colors.addAll(getRainbowColors(120, 50));
     loadDialsFromDb();
   }
 
   Future<void> loadDialsFromDb() async {
     /* TEST CODE */
-    // await DbManager().clear();
-    // await NotiManager().removeAllNotifications();
-    // await addDial("다이얼1", DateTime.now(), WeekSchedule(monday: Schedule(Time(15, 30)), tuesday: Schedule(Time(20, 30))));
-    // await addDial("다이얼2", DateTime.now(), WeekSchedule(friday: Schedule(Time(17, 30))));
-    // await addDial("다이얼3", DateTime.now(), WeekSchedule(wednesday: Schedule(Time(1, 30))), disabled: true);
+    await DbManager().clear();
+    await NotiManager().removeAllNotifications();
+    await addDial(
+        "다이얼1",
+        DateTime.now(),
+        WeekSchedule(
+            monday: Schedule(Time(15, 30)), tuesday: Schedule(Time(20, 30))));
+    await addDial(
+        "다이얼2", DateTime.now(), WeekSchedule(friday: Schedule(Time(17, 30))));
+    await addDial(
+        "다이얼3", DateTime.now(), WeekSchedule(wednesday: Schedule(Time(1, 30))),
+        disabled: true);
+    await addDial(
+        "다이얼4",
+        DateTime.now(),
+        WeekSchedule(
+            wednesday: Schedule(Time(21, 5)),
+            sunday: Schedule(Time(9, 30), Time(21, 30))));
 
     dials.addAll(await DbManager().loadAllDials());
     notifyObservers();
@@ -126,12 +146,14 @@ class DialManager {
   /// 모든 다이얼의 일정 Appointment로 리턴
   List<Appointment> getAllDialsAsAppointments() {
     var result = List<Appointment>.empty(growable: true);
+    int colorPicker = 0;
 
     for (Dial dial in getAllDials()) {
       if (dial.disabled) {
         result.addAll(dial.toAppointments(CupertinoColors.inactiveGray));
       } else {
-        result.addAll(dial.toAppointments(CupertinoColors.activeBlue));
+        result.addAll(dial.toAppointments(_colors[colorPicker]));
+        colorPicker = (colorPicker + 1) % _colors.length;
       }
     }
 

--- a/lib/models/dial_manager.dart
+++ b/lib/models/dial_manager.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:plan_dial_renewal/models/dial.dart';
-import 'package:plan_dial_renewal/models/schedule.dart';
-import 'package:plan_dial_renewal/models/time.dart';
 import 'package:plan_dial_renewal/models/week_schedule.dart';
 import 'package:plan_dial_renewal/utils/db_manager.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
@@ -30,24 +28,12 @@ class DialManager {
 
   Future<void> loadDialsFromDb() async {
     /* TEST CODE */
-    await DbManager().clear();
-    await NotiManager().removeAllNotifications();
-    await addDial(
-        "다이얼1",
-        DateTime.now(),
-        WeekSchedule(
-            monday: Schedule(Time(15, 30)), tuesday: Schedule(Time(20, 30))));
-    await addDial(
-        "다이얼2", DateTime.now(), WeekSchedule(friday: Schedule(Time(17, 30))));
-    await addDial(
-        "다이얼3", DateTime.now(), WeekSchedule(wednesday: Schedule(Time(1, 30))),
-        disabled: true);
-    await addDial(
-        "다이얼4",
-        DateTime.now(),
-        WeekSchedule(
-            wednesday: Schedule(Time(21, 5)),
-            sunday: Schedule(Time(9, 30), Time(21, 30))));
+    // await DbManager().clear();
+    // await NotiManager().removeAllNotifications();
+    // await addDial("다이얼1", DateTime.now(), WeekSchedule(monday: Schedule(Time(15, 30)), tuesday: Schedule(Time(20, 30))));
+    // await addDial("다이얼2", DateTime.now(), WeekSchedule(friday: Schedule(Time(17, 30))));
+    // await addDial("다이얼3", DateTime.now(), WeekSchedule(wednesday: Schedule(Time(1, 30))), disabled: true);
+    // await addDial("다이얼4", DateTime.now(), WeekSchedule(wednesday: Schedule(Time(21, 5)), sunday: Schedule(Time(9, 30), Time(21, 30))));
 
     dials.addAll(await DbManager().loadAllDials());
     notifyObservers();

--- a/lib/screens/calendar.dart
+++ b/lib/screens/calendar.dart
@@ -12,12 +12,21 @@ class Calendar extends StatefulWidget {
 class _CalendarState extends State<Calendar> {
   @override
   Widget build(BuildContext context) {
+    final now = DateTime.now();
+    DateTime baseDate = DateTime(now.year, now.month, now.day);
+    baseDate = baseDate.subtract(Duration(days: baseDate.weekday - 1));
+
     return SfCalendar(
       view: CalendarView.week,
       timeSlotViewSettings:
           const TimeSlotViewSettings(timeInterval: Duration(hours: 2)),
       headerHeight: 0,
       dataSource: MeetingDataSource(DialManager().getAllDialsAsAppointments()),
+      firstDayOfWeek: 1,
+      maxDate: baseDate
+          .add(const Duration(days: 7))
+          .subtract(const Duration(seconds: 1)),
+      minDate: baseDate,
     );
   }
 }

--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -1,0 +1,13 @@
+import 'dart:ui';
+
+/// Returns Rainbow colors
+List<Color> getRainbowColors(int bright, int dark, {int alpha = 255}) {
+  return [
+    Color.fromARGB(alpha, bright, dark, dark),
+    Color.fromARGB(alpha, bright, (dark + (bright - dark) * 0.7).round(), dark),
+    Color.fromARGB(alpha, dark, bright, dark),
+    Color.fromARGB(alpha, dark, bright, bright),
+    Color.fromARGB(alpha, dark, dark, bright),
+    Color.fromARGB(alpha, bright, dark, bright),
+  ];
+}


### PR DESCRIPTION
## 개요
캘린더에 다이얼별 색상 적용

## 변경 사항
+ **캘린더에 다이얼별로 다른 색상이 적용됩니다.**
    - Id 순서대로 빨-노-초-파-남-보가 적용되며, 이후 톤을 다운하여 다시 빨간색부터 적용됩니다.
    - 미리 지정해 놓은 색을 모두 소진하면 다시 빨강부터 적용됩니다만, 이 경우는 다이얼이 19개 이상인 경우입니다...
    설마 이렇게 쓰는 사람이 있겠어요? ㅎㅎㅎ
+ **더이상 캘린더가 좌우로 스크롤되지 않습니다.**
  - minDate와 maxDate를 지정하는 방식으로 해결했습니다.

## 확인 방법 (스크린샷 첨부 가능)
![image](https://user-images.githubusercontent.com/43088187/167861071-26119690-879e-4724-8bc3-b0fdec3d0d44.png)

## 한계점 / 문제점
딱히...? 없는... 것... 같네요!