### PR TITLE
feat: Icon change and change Tab bar height

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,7 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
@@ -9,6 +11,7 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
 
 SPEC REPOS:
@@ -18,11 +21,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
 
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
 

--- a/lib/screens/main.dart
+++ b/lib/screens/main.dart
@@ -43,13 +43,13 @@ class BottomNavigation extends StatelessWidget {
   Widget build(BuildContext context) {
     List<BottomNavigationBarItem> items = [
       const BottomNavigationBarItem(
-          icon: Icon(CupertinoIcons.star_fill), label: 'Dial'),
+          icon: Icon(CupertinoIcons.clock), label: 'Dial'),
       const BottomNavigationBarItem(
-          icon: Icon(CupertinoIcons.star_fill), label: 'Time Table'),
+          icon: Icon(CupertinoIcons.table), label: 'Table'),
     ];
 
     return CupertinoTabScaffold(
-      tabBar: CupertinoTabBar(items: items),
+      tabBar: CupertinoTabBar(items: items, height: 55),
       tabBuilder: (context, index) {
         switch (index) {
           case 0:


### PR DESCRIPTION
## 개요
1. Bottom Navigation Tab Bar의 기존의 아이콘을 조금 더 직관적인 아이콘으로 변경함.
2. Android 환경에서 Bottom Navigation Tab Bar 와 제스쳐 버튼의 곂침으로 인한 불편함을
Height 변경으로 해결해봄.

## 변경 사항
아이콘 변경 및 높이 조절

## 확인 방법 (스크린샷 첨부 가능)
![Simulator Screen Shot - iPhone 13 - 2022-05-12 at 11 50 16](https://user-images.githubusercontent.com/85606158/167982265-cba28fa1-bf27-438c-a745-64ae407c02a5.png)

## 한계점 / 문제점
Tab bar의 모양이 IOS 와 Android와 조금 다르게 표현되는 현상이 있음. 
크게 문제 될 것 같진 않지만 조금 거슬림... ㅎㅎ 
최종 본 피드백 시 디자인적인 관점에서 논의해보면 좋을수도..?
