### PR TITLE
메인 페이지에 다이얼 추가 버튼 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:label="plan_dial_renewal">
+        android:label="Plan Dial">
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Plan Dial Renewal</string>
+	<string>Plan Dial</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/screens/Add_Dial.dart
+++ b/lib/screens/Add_Dial.dart
@@ -92,7 +92,6 @@ class _AddDialNameState extends State<AddDialName> {
         children: [
           Expanded(
             child: CupertinoTextField(
-              autofocus: true,
               keyboardType: TextInputType.text,
               autocorrect: false,
               controller: dialNameController,


### PR DESCRIPTION
## 개요
메인 페이지에 다이얼 추가 버튼 추가

## 변경 사항
다이얼이 없을 때: Next 내 항목 자체가 버튼이 됨.
다이얼이 있을 때: Dials 인덱스에 버튼이 생김.
앱 설치시 표시되는 이름 수정.

## 확인 방법 (스크린샷 첨부 가능)
![image](https://user-images.githubusercontent.com/43088187/168639508-811dda30-43b6-4311-8bbb-8aed13a0c6d6.png)
![image](https://user-images.githubusercontent.com/43088187/168639532-edfd49c8-e14d-4523-ba6c-bc99b4f118bd.png)

## 한계점 / 문제점
사실 Next 내의 버튼은... Material 버튼입니다 ㅎㅎ